### PR TITLE
Add snap to secure_path for Ubuntu

### DIFF
--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -3,7 +3,7 @@
 
 sudoers_sudoers_preset_defaults:
   - env_reset
-  - 'secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"'
+  - 'secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"'
 
 sudoers_sudoers_preset_privileges:
   - name: root


### PR DESCRIPTION
Hello,

Just a small commit to add /snap/bin to secure_path. This way the Ubuntu systems that already have this path filled in and that is the only difference with the default sudoers of this role will not have the sudoers file overwritten.
For systems that do not have it, however, it will be overwritten. I leave it to you to decide what is better or not.