### PR TITLE
Fix visudo check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,7 @@
   ansible.builtin.template:
     src: etc/sudoers.d/sudoers.j2
     dest: '/etc/sudoers.d/{{ item.key }}'
-    validate: 'visudo -cf %s'
+    validate: /usr/sbin/visudo -cf %s
     owner: root
     group: root
     mode: 0440
@@ -48,7 +48,7 @@
   ansible.builtin.template:
     src: etc/sudoers.j2
     dest: '{{ sudoers_sudoers_file }}'
-    validate: 'visudo -cf %s'
+    validate: /usr/sbin/visudo -cf %s
     owner: root
     group: root
     mode: 0440


### PR DESCRIPTION
In some cases when `/usr/sbin/visudo` isn't on the users PATH validation checks will fail when installing sudoers templates. Passing the full path to `visudo` for template validation is more reliable. This also more closely replicates the examples given in the official ansible docs: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/template_module.html. 